### PR TITLE
feat: thiserrorによる統一エラー型の実装

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ syn = { version = "2", features = ["full"] }
 proc-macro2 = "1.0"
 quote = "1.0"
 thiserror = "2.0"
-anyhow = "1.0"
 trybuild = { version = "1.0.105", features = ["diff"] }
 
 protowirers-impl = { version = "0.1.0", path = "impl" }

--- a/impl/Cargo.toml
+++ b/impl/Cargo.toml
@@ -13,5 +13,4 @@ syn = { version = "2", features = ["full"] }
 proc-macro2 = "1.0"
 quote = "1.0"
 thiserror = "2.0"
-anyhow = "1.0"
 

--- a/impl/src/expand.rs
+++ b/impl/src/expand.rs
@@ -20,7 +20,7 @@ fn gen_struct(data: Struct, input_indent: syn::Ident) -> proc_macro2::TokenStrea
 
     quote! {
         impl protowirers::wire::Proto for #input_indent{
-            fn parse(bytes: &[u8])->anyhow::Result<Self>{
+            fn parse(bytes: &[u8])->protowirers::Result<Self>{
                 use protowirers::parser::*;
 
                 let mut c = std::io::Cursor::new(bytes);
@@ -37,7 +37,7 @@ fn gen_struct(data: Struct, input_indent: syn::Ident) -> proc_macro2::TokenStrea
                     #build_fields
                 })
             }
-            fn bytes(&self)-> anyhow::Result<Vec<u8>>{
+            fn bytes(&self)-> protowirers::Result<Vec<u8>>{
                 use protowirers::parser::*;
 
                 let inputs = vec![

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use crate::Result;
 use std::convert::TryFrom;
 use std::io::{Cursor, Write};
 
@@ -133,7 +133,7 @@ mod tests {
             // assert_eq!(c.position(), 2);
 
             let x: Vec<u8> = c.into_inner();
-            assert_eq!(x, vec![]);
+            assert_eq!(x, vec![] as Vec<u8>);
         }
         {
             {
@@ -160,7 +160,7 @@ mod tests {
         {
             let mut v = Vec::new();
             encode_repeat(&mut v, vec![]).unwrap();
-            assert_eq!(v, vec![]);
+            assert_eq!(v, vec![] as Vec<u8>);
         }
         {
             let mut v = Vec::new();

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,32 @@
+use thiserror::Error;
+
+/// 統一エラー型
+#[derive(Error, Debug)]
+pub enum ProtowiresError {
+    /// デコードエラー
+    #[error("decode error: {0}")]
+    Decode(#[from] crate::decode::DecodeError),
+
+    /// パースエラー
+    #[error("parse error: {0}")]
+    Parse(#[from] crate::parser::ParseError),
+
+    /// IOエラー
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+
+    /// 数値変換エラー
+    #[error("numeric conversion error: {0}")]
+    TryFromInt(#[from] std::num::TryFromIntError),
+
+    /// 値が大きすぎるエラー
+    #[error("value too large: {value} exceeds maximum {max}")]
+    ValueTooLarge { value: u128, max: u128 },
+
+    /// UTF-8変換エラー
+    #[error("UTF-8 conversion error: {0}")]
+    FromUtf8(#[from] std::string::FromUtf8Error),
+}
+
+/// Result型のエイリアス
+pub type Result<T> = std::result::Result<T, ProtowiresError>;

--- a/src/error_test.rs
+++ b/src/error_test.rs
@@ -1,0 +1,134 @@
+#[cfg(test)]
+mod tests {
+    use crate::decode::DecodeError;
+    use crate::error::ProtowiresError;
+    use crate::parser::{ParseError, Parser};
+    use crate::wire::{TypeLengthDelimited, TypeVairant, WireDataLengthDelimited, WireDataVarint};
+
+    #[test]
+    fn test_value_too_large_error() {
+        let result = Parser::<u32>::parse(
+            &WireDataVarint::new((u32::MAX as u128) + 1),
+            TypeVairant::Uint32,
+        );
+
+        match result {
+            Err(ProtowiresError::TryFromInt(_)) => {
+                // u32の範囲を超える値はTryFromIntErrorとして処理される
+            }
+            _ => panic!("Expected TryFromInt error"),
+        }
+    }
+
+    #[test]
+    fn test_parse_error_type_mismatch() {
+        // Stringはvariantではなく、lengthDelimitedタイプなので、
+        // WireDataLengthDelimited経由でテストする必要がある
+        let wire_data = WireDataLengthDelimited::new(vec![0x41, 0x42]);
+        // Bytesタイプを期待しているところにWireStringを渡す
+        let result: Result<Vec<u8>, ProtowiresError> =
+            Parser::<Vec<u8>>::parse(&wire_data, TypeLengthDelimited::WireString);
+
+        match result {
+            Err(ProtowiresError::Parse(ParseError::UnexpectTypeError { want, got })) => {
+                assert!(want.contains("Bytes"));
+                assert!(got.contains("WireString"));
+            }
+            _ => panic!("Expected Parse error with type mismatch"),
+        }
+    }
+
+    #[test]
+    fn test_decode_error_unexpected_format() {
+        use crate::decode::decode_variants_slice;
+
+        let invalid_bytes = &[
+            0b10000000, 0b10000100, 0b10101111, 0b01011111, 0b00000100, 0b10000110,
+        ];
+        let result = decode_variants_slice(invalid_bytes);
+
+        match result {
+            Err(ProtowiresError::Decode(DecodeError::UnexpectFormat)) => {
+                // UnexpectFormat variant has no associated message
+            }
+            _ => panic!("Expected Decode error with UnexpectFormat"),
+        }
+    }
+
+    #[test]
+    fn test_io_error_propagation() {
+        use std::io::{Cursor, Read};
+
+        // Create a cursor that will fail on read
+        let mut cursor = Cursor::new(vec![]);
+        let mut buf = [0u8; 10];
+
+        // Force EOF error
+        cursor.set_position(100);
+        let io_result = cursor.read_exact(&mut buf);
+
+        // Convert to our error type
+        let our_result: Result<(), ProtowiresError> = io_result.map_err(Into::into);
+
+        match our_result {
+            Err(ProtowiresError::Io(_)) => {
+                // IO error properly propagated
+            }
+            _ => panic!("Expected IO error"),
+        }
+    }
+
+    #[test]
+    fn test_utf8_error() {
+        use crate::parser::Parser;
+        use crate::wire::{TypeLengthDelimited, WireDataLengthDelimited};
+
+        // Invalid UTF-8 sequence
+        let invalid_utf8 = vec![0xFF, 0xFE, 0xFD];
+        let wire_data = WireDataLengthDelimited::new(invalid_utf8);
+        let result = Parser::<String>::parse(&wire_data, TypeLengthDelimited::WireString);
+
+        match result {
+            Err(ProtowiresError::FromUtf8(_)) => {
+                // UTF-8 error properly caught
+            }
+            _ => panic!("Expected UTF-8 error"),
+        }
+    }
+
+    #[test]
+    fn test_error_display() {
+        let err = ProtowiresError::ValueTooLarge {
+            value: 1000,
+            max: 100,
+        };
+
+        let msg = err.to_string();
+        assert!(msg.contains("value too large"));
+        assert!(msg.contains("1000"));
+        assert!(msg.contains("100"));
+    }
+
+    #[test]
+    fn test_decode_error_variants() {
+        let err1 = DecodeError::UnexpectFormat;
+        let err2 = DecodeError::UnexpectedWireDataValue(99);
+
+        let proto_err1: ProtowiresError = err1.into();
+        let proto_err2: ProtowiresError = err2.into();
+
+        match proto_err1 {
+            ProtowiresError::Decode(DecodeError::UnexpectFormat) => {
+                // UnexpectFormat variant has no associated message
+            }
+            _ => panic!("Unexpected error variant"),
+        }
+
+        match proto_err2 {
+            ProtowiresError::Decode(DecodeError::UnexpectedWireDataValue(val)) => {
+                assert_eq!(val, 99);
+            }
+            _ => panic!("Unexpected error variant"),
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,12 @@
 pub mod decode;
 pub mod encode;
+pub mod error;
 pub mod parser;
 pub mod wire;
 mod zigzag;
 
+#[cfg(test)]
+mod error_test;
+
+pub use error::{ProtowiresError, Result};
 pub use protowirers_impl::*;

--- a/src/wire.rs
+++ b/src/wire.rs
@@ -1,5 +1,5 @@
 use crate::zigzag::ZigZag;
-use anyhow::Result;
+use crate::Result;
 use std::fmt::Display;
 
 pub trait Proto {

--- a/tests/sample.rs
+++ b/tests/sample.rs
@@ -5,9 +5,9 @@ struct Sample {
     // #[proto_def(field_num=2, p_type=sint64)]
     x: i64,
 }
-use anyhow::Result;
 use protowirers::parser::Parser;
 use protowirers::wire::*;
+use protowirers::Result;
 use protowirers::{decode, encode};
 use std::io::Cursor;
 impl Sample {


### PR DESCRIPTION
- anyhowをthiserrorに置き換え、ライブラリ向けの適切なエラーハンドリングを実装
- 統一エラー型ProtowiresErrorを作成し、すべてのエラーを集約
- 各エラーバリアントに対する包括的なテストを追加
- エラーメッセージをより詳細で分かりやすく改善

🤖 Generated with [Claude Code](https://claude.ai/code)