### PR TITLE
Update Rust to 1.96 and trybuild snapshot

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.87.0"
+channel = "1.96.0"
 components = ["rustfmt", "clippy"]
 profile = "default"

--- a/tests/compile_fail/no_def_attribute.stderr
+++ b/tests/compile_fail/no_def_attribute.stderr
@@ -8,4 +8,10 @@ error: cannot find attribute `defx` in this scope
  --> $DIR/no_def_attribute.rs:5:7
   |
 5 |     #[defx(field_num = 1, def_type = "int32")]
-  |       ^^^^ help: a derive helper attribute with a similar name exists: `def`
+  |       ^^^^
+  |
+help: a derive helper attribute with a similar name exists
+  |
+5 -     #[defx(field_num = 1, def_type = "int32")]
+5 +     #[def(field_num = 1, def_type = "int32")]
+  |


### PR DESCRIPTION
## Summary
- update Rust toolchain to 1.96.0
- update the trybuild stderr snapshot for Rust 1.96's expanded helper-attribute diagnostic

## Validation
- env -u RUSTUP_TOOLCHAIN cargo test --test conpiletests
- env -u RUSTUP_TOOLCHAIN cargo test
